### PR TITLE
Add `Serializable` and `Transferable` interfaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ exports.constants = constants
 exports.errors = errors
 
 exports.Serializable = class Serializable {
-  [Symbol.for('bare.serialize')] () {}
+  [Symbol.for('bare.serialize')] (forStorage) {}
 
-  static [Symbol.for('bare.deserialize')] () {}
+  static [Symbol.for('bare.deserialize')] (serialized) {}
 }
 
 exports.Transferable = class Transferable {
@@ -49,7 +49,7 @@ exports.Transferable = class Transferable {
     this.detached = true
   }
 
-  static [Symbol.for('bare.attach')] () {}
+  static [Symbol.for('bare.attach')] (serialized) {}
 }
 
 class InterfaceMap {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -40,6 +40,8 @@ module.exports = {
     URL: 22,
     BUFFER: 23,
     EXTERNAL: 24,
+    SERIALIZABLE: 25,
+    TRANSFERABLE: 26,
 
     typedarray: {
       UINT8ARRAY: 1,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -31,4 +31,8 @@ module.exports = class DataCloneError extends Error {
   static INVALID_REFERENCE (msg) {
     return new DataCloneError(msg, 'INVALID_REFERENCE', DataCloneError.INVALID_REFERENCE)
   }
+
+  static INVALID_INTERFACE (msg) {
+    return new DataCloneError(msg, 'INVALID_INTERFACE', DataCloneError.INVALID_INTERFACE)
+  }
 }


### PR DESCRIPTION
The `Serializable` interface has two methods defined by the well-known symbols `Symbol.for('bare.serialize')` and `Symbol.for('bare.deserialize')`. The former is an instance method that returns a serializable representation of the class instance. The latter is a class method that takes that same representation and creates a class instance.

Likewise, the `Transferable` interface two methods defined by the well-known symbols `Symbol.for('bare.detach')` and `Symbol.for('bare.attach')` as well as an optional named `detached` property. The former method is an instance method that detaches the class instance and returns a serializable representation of the data to transfer, such as an `External` pointer. The former method is a class method that takes that same data and creates a class instance with the data attached.

To actually use classes that implement these interfaces during serialization and deserialization, the classes must be registered. This happens via new function arguments:

```js
class Foo extends Serializable {}

const serialized = serialize(new Foo(), false, [Foo])

deserialize(serialized, [Foo])
```

```js
class Foo extends Transferable {}

const foo = new Foo()

const serialized = serializeWithTransfer(foo, [foo], [Foo])

deserializeWithTransfer(serialized, [Foo])
```

Attempts to serialize or transfer unregistered interfaces will throw.